### PR TITLE
fix(security): vite: Vite bypasses server.fs.deny when using `?raw??`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "postcss": "^8.4.35",
         "tailwindcss": "^3.4.1",
         "typescript": "^5.2.2",
-        "vite": "^6.2.2"
+        "vite": "^6.2.3"
       }
     },
     "apps/localstorage-example/node_modules/@eslint/eslintrc": {
@@ -12624,7 +12624,7 @@
       "dependencies": {
         "lint-staged": "^15.5.0",
         "lz-string": "^1.5.0",
-        "vite": "6.2.2"
+        "vite": "6.2.3"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.1.4",


### PR DESCRIPTION
## Summary

This pull request applies an automated security remediation generated by **KubbiSec** (kbs fix).

## Finding

| Field | Value |
| --- | --- |
| **Title** | vite: Vite bypasses server.fs.deny when using `?raw??` |
| **Severity** | MEDIUM |
| **ID** | a6ac7bec-5d7b-45dc-a53b-7f34ee254e49 |
| **Component** | vite |
| **Location** | package-lock.json |

### Description

Vite, a provider of frontend development tooling, has a vulnerability in versions prior to 6.2.3, 6.1.2, 6.0.12, 5.4.15, and 4.5.10. `@fs` denies access to files outside of Vite serving allow list. Adding `?raw??` or `?import&raw??` to the URL bypasses this limitation and returns the file content if it exists. This bypass exists because trailing separators such as `?` are removed in several places, but are not accounted for in query string regexes. The contents of arbitrary files can be returned to the browser. Only apps explicitly exposing the Vite dev server to the network (using `--host` or `server.host` config option) are affected. Versions 6.2.3, 6.1.2, 6.0.12, 5.4.15, and 4.5.10 fix the issue.

## Changes in this PR

**1** file(s) changed, **+2** / **-2** lines.

- `package-lock.json` (+2 / -2)

## Review notes

- Confirm the dependency/version or code change addresses the finding.
- Run project tests and security scans on this branch before merge.
- Harness task files (e.g. .kubbisec-ai-task.xml) are not included in this commit.