### PR TITLE
fix(security): Prototype Pollution via parse() in NodeJS flatted

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -545,7 +545,7 @@
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flatted": "^3.2.9",
+        "flatted": "^3.3.3",
         "keyv": "^4.5.3",
         "rimraf": "^3.0.2"
       },
@@ -6681,7 +6681,7 @@
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flatted": "^3.2.9",
+        "flatted": "^3.3.3",
         "keyv": "^4.5.4"
       },
       "engines": {
@@ -12966,7 +12966,7 @@
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flatted": "^3.2.9",
+        "flatted": "^3.3.3",
         "keyv": "^4.5.3",
         "rimraf": "^3.0.2"
       },


### PR DESCRIPTION
## Summary

This pull request applies an automated security remediation generated by **KubbiSec** (kbs fix).

## Finding

| Field | Value |
| --- | --- |
| **Title** | Prototype Pollution via parse() in NodeJS flatted |
| **Severity** | HIGH |
| **ID** | ba9f62bb-6223-4c5a-9444-bf4ab23f83fe |
| **Component** | flatted |
| **Location** | /home/gfrancodev/Documentos/test/brushy-librarys/package-lock.json |

### Description

---
  **Summary**

  The parse() function in flatted can use attacker-controlled string values from the parsed JSON as direct array index
  keys, without validating that they are numeric. Since the internal input buffer is a JavaScript Array, accessing it
  with the key "\_\_proto\_\_" returns Array.prototype via the inherited getter. This object is then treated as a legitimate
   parsed value and assigned as a property of the output object, effectively leaking a live reference to Array.prototype
   to the consumer. Any code that subsequently writes to that property will pollute the global prototype.

  ---
  **Root Cause**

  File: esm/index.js:29 (identical in cjs/index.js)
```
  const resolver = (input, lazy, parsed, $) => output => {
    for (let ke = keys(output), {length} = ke, y = 0; y < length; y++) {
      const k = ke[y];
      const value = output[k];    
      if (value instanceof Primitive) {
        const tmp = input[value];      // Bug is here
```

No validation that value is a safe numeric index input is built as a plain Array. JavaScript's property lookup on arrays traverses the prototype chain for non-numeric  keys. The key "\_\_proto\_\_" resolves to Array.prototype, which:

  - has type "object" → passes the typeof tmp === object guard at line 30
  - is not in the parsed Set yet → passes the !parsed.has(tmp) guard.
  - The reference to Array.prototype is then enqueued in lazy and later unconditionally assigned to the output object.
  ---
  **Replication Steps**
```
  const Flatted = require('flatted'); 
  const parsed = Flatted.parse('[{"x":"__proto__"}]');
  parsed.x.polluted = 'pwned';
  console.log([].polluted);  // Returns true
``` 
 ---
  **Impact**
 An attacker can supply a crafted flatted string to parse() that causes the returned object to hold a live reference to Array.prototype, enabling any downstream code that writes to that property to pollute the global prototype chain, potentially causing denial of service or code execution.

  **Recommended solution**
 Validate that the index string represents an integer within the bounds of input before accessing it:

  // Before (vulnerable)
  const tmp = input[value];

  // After (safe)
  const idx = +value;  // coerce boxed String → number
  const tmp = (Number.isInteger(idx) && idx >= 0 && idx < input.length)
    ? input[idx]
    : undefined;

## Changes in this PR

**1** file(s) changed, **+3** / **-3** lines.

- `package-lock.json` (+3 / -3)

## Review notes

- Confirm the dependency/version or code change addresses the finding.
- Run project tests and security scans on this branch before merge.
- Harness task files (e.g. .kubbisec-ai-task.xml) are not included in this commit.